### PR TITLE
Update fpv-vendors.md

### DIFF
--- a/fpv-vendors.md
+++ b/fpv-vendors.md
@@ -12,26 +12,26 @@ There should be some text here explaining the principles of entering into this t
 
 ### List of OpenIPC FPV supported devices
 
-| Device name                   | Vendor    | Processor | Sensor(s)        | WiFi                         |
-|:------------------------------|:---------:|:---------:|:----------------:|:----------------------------:|
-|[AIO Evolution v1.0](#)        | [OpenIPC](https://openipc.org)   | SSC338Q   | IMX335           | RTL8812AU                    |
-|[AIO Thinker Base v1.0](#)     | [OpenIPC](https://openipc.org)   | SSC338Q   | IMX335           | for external USB device      |
-|[AIO Thinker Tiny v1.0](#)     | [OpenIPC](https://openipc.org)   | SSC338Q   | IMX335           | RTL8731BU                    |
-|[AIO Mario v1.0](#)            | [OpenIPC](https://openipc.org)   | SSC338Q   | IMX335, (IMX415) |                              |
-|[AIO Optimus v1.0](#)          | [OpenIPC](https://openipc.org)   | SSC338Q   | IMX415           |                              |
-|[AIO UltraSight v1.0](#)       | [OpenIPC](https://openipc.org)   | SSC338Q   | IMX415           |                              |
-|                               |           |           |                  |                              |
-|[one](#)                       | RunCam    | SSC338Q   | IMX ?            |                              |
-|[two](#)                       | RunCam    | SSC338Q   | IMX ?            |                              |
-|                               |           |           |                  |                              |
-|[one](#)                       | Emax USA  | SSC338Q   | IMX ?            |                              |
-|[two](#)                       | Emax USA  | SSC338Q   | IMX ?            |                              |
-|                               |           |           |                  |                              |
-|[CrazyCat R2](#)               | PocketFPV | SSC338Q   | IMX ?            |                              |
-|[BigRookie R1](#)              | PocketFPV | SSC338Q   | IMX ?            |                              |
-|                               |           |           |                  |                              |
-|[OIPC S338](#)                 | ElfinRC   | SSC338Q   | IMX ?            |                              |
-|[Mini IPC](https://www.youtube.com/watch?v=eQ_vbyScS4c) | ElfinRC   | SSC338Q   | IMX415            |                              |
+| Device name                   | Vendor    | Processor | Sensor(s)        | MIPI compatibility | WiFi                         |
+|:------------------------------|:---------:|:---------:|:----------------:|:------------------:|:----------------------------:|
+|[AIO Evolution v1.0](#)        | [OpenIPC](https://openipc.org)   | SSC338Q   | IMX335           | openIPC          | RTL8812AU                    |
+|[AIO Thinker Base v1.0](#)     | [OpenIPC](https://openipc.org)   | SSC338Q   | IMX335           | openIPC          | for external USB device      |
+|[AIO Thinker Tiny v1.0](#)     | [OpenIPC](https://openipc.org)   | SSC338Q   | IMX335           | openIPC          | RTL8731BU                    |
+|[AIO Mario v1.0](#)            | [OpenIPC](https://openipc.org)   | SSC338Q   | IMX335, (IMX415) | openIPC          |                              |
+|[AIO Optimus v1.0](#)          | [OpenIPC](https://openipc.org)   | SSC338Q   | IMX415           | openIPC          |                              |
+|[AIO UltraSight v1.0](#)       | [OpenIPC](https://openipc.org)   | SSC338Q   | IMX415           | openIPC          |                              |
+|                               |           |           |                  |                    |                              |
+|[one](#)                       | RunCam    | SSC338Q   | IMX ?            | ?                  |                              |
+|[two](#)                       | RunCam    | SSC338Q   | IMX ?            | ?                  |                              |
+|                               |           |           |                  |                    |                              |
+|[one](#)                       | Emax USA  | SSC338Q   | IMX ?            | ?                  |                              |
+|[two](#)                       | Emax USA  | SSC338Q   | IMX ?            | ?                  |                              |
+|                               |           |           |                  |                    |                              |
+|[CrazyCat R2](#)               | PocketFPV | SSC338Q   | IMX ?            | ?                  |                              |
+|[BigRookie R1](#)              | PocketFPV | SSC338Q   | IMX ?            | ?                  |                              |
+|                               |           |           |                  |                    |                              |
+|[OIPC S338](#)                 | ElfinRC   | SSC338Q   | IMX ?            | ?                  |                              |
+|[Mini IPC](https://www.youtube.com/watch?v=eQ_vbyScS4c) | ElfinRC   | SSC338Q   | IMX415            | ?   
 
 
 [logo]: https://openipc.org/assets/openipc-logo-black.svg


### PR DESCRIPTION
I added a column with MIPI compability.

Perhaps we could make something that covers all of the hardware compability that we want? This would mean that every vendor for it to be supported by OIPC has to have for example certain IMU and our MIPI pinout. Confirm with Kenny to set those standards so they are futureproof at least for few years.

The column could then change into "OIPC hardware compability"